### PR TITLE
Add a `StrLookup` implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,26 @@
 	<name>custom-context-data-provider</name>
 	<description>a sample project</description>
 
+	<properties>
+		<maven.compiler.release>11</maven.compiler.release>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.23.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.25.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.10.1</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/custom/context/data/provider/MyContextDataProvider.java
+++ b/src/main/java/custom/context/data/provider/MyContextDataProvider.java
@@ -5,9 +5,11 @@ import org.apache.logging.log4j.core.util.ContextDataProvider;
 
 public class MyContextDataProvider implements ContextDataProvider {
 
+  static final Map<String, String> MAP = Map.of("tenant", "tenant1");
+
   @Override
   public Map<String, String> supplyContextData() {
-    return Map.of("tenant", "tenant1");
+    return MAP;
   }
 
 }

--- a/src/main/java/custom/context/data/provider/MyStrLookup.java
+++ b/src/main/java/custom/context/data/provider/MyStrLookup.java
@@ -1,0 +1,18 @@
+package custom.context.data.provider;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+
+@Plugin(name = "my", category = StrLookup.CATEGORY)
+public class MyStrLookup implements StrLookup{
+    @Override
+    public String lookup(final String key) {
+        return MyContextDataProvider.MAP.get(key);
+    }
+
+    @Override
+    public String lookup(final LogEvent event, final String key) {
+        return lookup(key);
+    }
+}

--- a/src/test/java/custom/context/data/provider/MyContextDataProviderTest.java
+++ b/src/test/java/custom/context/data/provider/MyContextDataProviderTest.java
@@ -1,18 +1,21 @@
 package custom.context.data.provider;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Paths;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class MyContextDataProviderTest {
 
   @Test
   void test() {
-    // it works when the tenant is set via the ThreadContext
-    // ThreadContext.put("tenant", "tenant1");
-
     Logger logger = LogManager.getLogger("MyLogger");
-    logger.info("Hello tenant1");
+    logger.info("Hello");
+    assertThat(Paths.get("target/logs/tenant1/logs.log")).content()
+            .contains("tenant1");
   }
 
 }

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -1,22 +1,18 @@
 status = info
 monitorInterval= 30
  
-property.LOG_DIR = src/test/logs/${ctx:tenant}
+property.LOG_DIR = target/logs/${my:tenant}
   
-appender.normal.type = RollingFile
+appender.normal.type = File
 appender.normal.name = NormalLog
 appender.normal.fileName = ${LOG_DIR}/logs.log
-appender.normal.filePattern = ${LOG_DIR}/logs.log.zip
 appender.normal.layout.type = PatternLayout
-appender.normal.layout.pattern = %d -%.-1level- %23.-23logger{0} | %msg%n
-appender.normal.policies.type = Policies
-appender.normal.policies.size.type = SizeBasedTriggeringPolicy
-appender.normal.policies.size.size = 50 KB
+appender.normal.layout.pattern = %X{tenant}%n
 
 appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d -%.-1level- %23.-23logger{0} | %msg%n
+appender.console.layout.pattern = %d -%.-1level- %23.-23logger{0} | %msg %X{tenant}%n
 
 logger.junit.name = org.junit
 logger.junit.level = OFF


### PR DESCRIPTION
If you add a `StrLookup` the lookup can take care of the configuration file, while the `ContextDataProvider` will take care of the log event data.

The problem you reported in apache/logging-log4j2#2331 is not trivial to solve.